### PR TITLE
Switch to Maven GPG Plugin for Signing / Fix GPG Sig Deployment

### DIFF
--- a/jaxrpc-ri/build.xml
+++ b/jaxrpc-ri/build.xml
@@ -994,14 +994,10 @@
   </target>
 
   <!-- Prepare files uploaded to Maven repository.
-  Generates binary JARs, source JARs, Javadoc jars
-  and GPG signatures for Maven upload in ${build.home} directory.
+  Generates binary JARs, source JARs, and Javadoc jars
+  for Maven upload in ${build.home} directory.
 
   These files can then be manually uploaded to Maven.
-
-  Additional GPG options can be passed by providing a wrapper script that
-  invokes GPG with the desired options, then providing the path to the wrapper
-  script in the GPG_CCOMMAND environment variable.
   -->
   <target name="maven-distribution" depends="image">
     <mkdir dir="${maven.dist.dir}" />
@@ -1053,49 +1049,9 @@
 
     <copy file="${basedir}/maven/jaxrpc-spi.pom" tofile="${maven.dist.dir}/jaxrpc-spi-${pkg.version}.pom" />
     <copy file="${basedir}/maven/jaxrpc-impl.pom" tofile="${maven.dist.dir}/jaxrpc-impl-${pkg.version}.pom" />
-
-    <!-- signing -->
-    <property environment="env"/>
-    <property name="env.GPG_COMMAND" value="gpg"/>
-
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-impl-${pkg.version}.pom" />
-    </exec>
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-spi-${pkg.version}.pom" />
-    </exec>
-
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-impl-${pkg.version}.jar" />
-    </exec>
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-spi-${pkg.version}.jar" />
-    </exec>
-
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-impl-${pkg.version}-sources.jar" />
-    </exec>
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-spi-${pkg.version}-sources.jar" />
-    </exec>
-
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-impl-${pkg.version}-javadoc.jar" />
-    </exec>
-    <exec executable="${env.GPG_COMMAND}">
-      <arg value="-ab" />
-      <arg value="${maven.dist.dir}/jaxrpc-spi-${pkg.version}-javadoc.jar" />
-    </exec>
   </target>
 
-  <!-- Upload binaries, source JARs, and Javadocs to remote Maven repository.
+  <!-- Sign and upload binaries, source JARs, and Javadocs to remote Maven repository.
   Repository ID must be provided via the MVN_REPO_ID environment variable.
   Repository URL must be provided via the MVN_REPO_URL environment variable.
     -->
@@ -1103,9 +1059,10 @@
     <property environment="env"/>
     <property name="env.MVN_REPO_ID" value=""/>
     <property name="env.MVN_REPO_URL" value=""/>
+    <property name="env.GPG_DEFAULT_KEY" value=""/>
 
     <exec executable="mvn">
-      <arg value="deploy:deploy-file" />
+      <arg value="gpg:sign-and-deploy-file" />
       <arg value="--batch-mode" />
       <arg value="-DgeneratePom=false" />
       <arg value="-DrepositoryId=${env.MVN_REPO_ID}" />
@@ -1114,10 +1071,11 @@
       <arg value="-Dfile=${maven.dist.dir}/jaxrpc-impl-${pkg.version}.jar" />
       <arg value="-Dsources=${maven.dist.dir}/jaxrpc-impl-${pkg.version}-sources.jar" />
       <arg value="-Djavadoc=${maven.dist.dir}/jaxrpc-impl-${pkg.version}-javadoc.jar" />
+      <arg value="-Dgpg.keyname=${env.GPG_DEFAULT_KEY}" />
     </exec>
 
     <exec executable="mvn">
-      <arg value="deploy:deploy-file" />
+      <arg value="gpg:sign-and-deploy-file" />
       <arg value="--batch-mode" />
       <arg value="-DgeneratePom=false" />
       <arg value="-DrepositoryId=${env.MVN_REPO_ID}" />
@@ -1126,6 +1084,7 @@
       <arg value="-Dfile=${maven.dist.dir}/jaxrpc-spi-${pkg.version}.jar" />
       <arg value="-Dsources=${maven.dist.dir}/jaxrpc-spi-${pkg.version}-sources.jar" />
       <arg value="-Djavadoc=${maven.dist.dir}/jaxrpc-spi-${pkg.version}-javadoc.jar" />
+      <arg value="-Dgpg.keyname=${env.GPG_DEFAULT_KEY}" />
     </exec>
   </target>
   

--- a/jaxrpc-ri/wren-build.sh
+++ b/jaxrpc-ri/wren-build.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
+
 set -e
 set -u
-
-export GPG_COMMAND='./wren-gpg.sh'
-export GPG_DEFAULT_KEY="D7F749B5"
-export GPG_KEY_PASSPHRASE="${D7F749B5_PASSPHRASE}"
 
 ./build.sh clean ${1:-maven-distribution}

--- a/jaxrpc-ri/wren-deploy.sh
+++ b/jaxrpc-ri/wren-deploy.sh
@@ -2,7 +2,33 @@
 set -e
 set -u
 
+# `D7F749B5` could have applied here if we didn't have our own fork of this
+# project; but since we're modifying the project slightly and adding our own
+# version stamp suffix, it seems more genuine to consider this a project we
+# "produce" artifacts for.
+export GPG_DEFAULT_KEY="C081F89B"
+
 export MVN_REPO_ID='wrensecurity-releases'
 export MVN_REPO_URL='https://wrensecurity.jfrog.io/wrensecurity/releases'
+
+IS_GPG1=$(gpg --version | head | grep -q "gpg (GnuPG) 1" && echo 1 || echo 0)
+
+# Only GPG v1 allows us to preload the passphrase.
+if [[ "${IS_GPG1}" -eq 1 ]]; then
+  passphrase_var="${GPG_DEFAULT_KEY}_PASSPHRASE"
+
+  # Check if `wren-preload-creds` has already loaded this passphrase
+  if [[ -z "${!passphrase_var:-}" ]]; then
+    echo "Passphrase for GPG key '${GPG_DEFAULT_KEY}': "
+    read -s "${passphrase_var}"
+  fi
+
+  export GPG_KEY_PASSPHRASE="${!passphrase_var}"
+else
+  echo "NOTE: GPG will prompt you for signing passphrase '${GPG_DEFAULT_KEY}'."
+  echo ""
+
+  export GPG_TTY=$(tty)
+fi
 
 ./wren-build.sh maven-deploy

--- a/jaxrpc-ri/wren-gpg.sh
+++ b/jaxrpc-ri/wren-gpg.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-set -u
-
-gpg --default-key "${GPG_DEFAULT_KEY}" --passphrase "${GPG_KEY_PASSPHRASE}" \
-  --no-use-agent \
-  --batch --yes \
-  $@


### PR DESCRIPTION
- Eliminates manual invocation of the GPG command. If users need a locally-signed copy of build artifacts, they will need to manually sign them.
- Switches from `deploy:deploy-file` to `gpg:sign-and-deploy-file` so that Maven takes care of signing EVERY artifact and UPLOADING the signatures to JFrog for us.
- Switches from using the `D7F749B5` signing key to using `C081F89B` since we have made modifications to this project so we are producing our own artifacts instead of just signing existing artifacts.